### PR TITLE
Documentation fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV OTP_GRAPHS /var/otp/graphs
 RUN \
   mkdir -p /var/otp/graphs && \
   wget -P /var/otp/graphs http://www.transitchicago.com/downloads/sch_data/google_transit.zip && \
+  wget -P /var/otp/graphs https://s3.amazonaws.com/metro-extracts.mapzen.com/chicago_illinois.osm.pbf && \
   java -Xmx8G -jar /var/otp/otp.jar --build /var/otp/graphs
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM debian:sid
 
 MAINTAINER Tristan Crockett <tristan.h.crockett@gmail.com>
 
-
 RUN \
   apt-get update && \
   apt-get install -y openjdk-8-jre wget
@@ -16,7 +15,9 @@ ENV OTP_GRAPHS /var/otp/graphs
 
 RUN \
   mkdir -p /var/otp/graphs && \
-  wget -P /var/otp/graphs http://www.transitchicago.com/downloads/sch_data/google_transit.zip && \
+  wget -O /var/otp/graphs/pace.zip http://www.pacebus.com/gtfs/gtfs.zip && \
+  wget -O /var/otp/graphs/metra.zip http://transitfeeds.com/p/metra/169/latest/download && \
+  wget -O /var/otp/graphs/cta.zip http://www.transitchicago.com/downloads/sch_data/google_transit.zip && \
   wget -P /var/otp/graphs https://s3.amazonaws.com/metro-extracts.mapzen.com/chicago_illinois.osm.pbf && \
   java -Xmx8G -jar /var/otp/otp.jar --build /var/otp/graphs
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 # docker-otp-chicago
 Docker setup for a Chicago OpenTripPlanner instance
 
+Includes GTFS feeds from Metra, Pace, and CTA
+
 ## How to setup (Mac OS X)
 Clone the repo, cd into it
 ```
-docker-machine create -d virtualbox --virtualbox-memory 8192 cta-otp
-eval $(docker-machine env cta-otp)
-docker build -t cta-otp .
+docker-machine create -d virtualbox --virtualbox-memory 8192 chicago-otp
+eval $(docker-machine env chicago-otp)
+docker build -t chicago-otp .
 ```
 
 Then, after it finishes, run
-`docker run -p 8080:8080 cta-otp --autoScan --server`
+`docker run -p 80:8080 chicago-otp --autoScan --server`
 
 You can also run with the `--analyst` option to use OTP Analyst features
 
-Open a separate terminal window and run `docker-machine ls` to get the IP address for the container
+Open a separate terminal window and run `docker-machine ip chicago-otp` to get the IP address for the container
 
-Now you should be able to access it in your browser at `<INSERTIP>:8080`
+Now you should be able to access it in your browser at that IP address
 
 ## How to setup (Linux)
 Similar to the OSX instructions, but without the extra docker-machine steps at the beginning.
 ```
-docker build -t cta-otp .
-docker run -p 8080:8080 cta-otp --autoScan --server
+docker build -t chicago-otp .
+docker run -p 80:8080 chicago-otp --autoScan --server
 ```

--- a/README.md
+++ b/README.md
@@ -6,17 +6,19 @@ Clone the repo, cd into it
 ```
 docker-machine create --driver virtualbox cta-otp
 eval $(docker-machine env cta-otp)
-docker build -t cta-otp
+docker build -t cta-otp .
 ```
 
 Then, after it finishes, run
 `docker run -p 8080:8080 cta-otp --autoScan --server`
 
-Now it should be running at `localhost:8080`
+Open a separate terminal window and run `docker-machine ls` to get the IP address for the container
+
+Now you should be able to access it in your browser at `<INSERTIP>:8080`
 
 ## How to setup (Linux)
 Similar to the OSX instructions, but without the extra docker-machine steps at the beginning.
 ```
-docker build -t cta-otp
+docker build -t cta-otp .
 docker run -p 8080:8080 cta-otp --autoScan --server
 ```

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ Docker setup for a Chicago OpenTripPlanner instance
 ## How to setup (Mac OS X)
 Clone the repo, cd into it
 ```
-docker-machine create --driver virtualbox cta-otp
+docker-machine create -d virtualbox --virtualbox-memory 8192 cta-otp
 eval $(docker-machine env cta-otp)
 docker build -t cta-otp .
 ```
 
 Then, after it finishes, run
 `docker run -p 8080:8080 cta-otp --autoScan --server`
+
+You can also run with the `--analyst` option to use OTP Analyst features
 
 Open a separate terminal window and run `docker-machine ls` to get the IP address for the container
 


### PR DESCRIPTION
Was missing a period in the `docker build` command, and corrected that you don't access the container in your browser through `localhost`, and how to find the IP on Mac
